### PR TITLE
Gitlab GitHub

### DIFF
--- a/lib/danger/ci_source/aaa_gitlab_ci_github_pr.rb
+++ b/lib/danger/ci_source/aaa_gitlab_ci_github_pr.rb
@@ -1,0 +1,49 @@
+require "danger/request_sources/github/github"
+
+module Danger
+  # ### CI Setup
+  #
+  # You can use `danger/danger` Action in your .github/main.workflow.
+  #
+  #  ```
+  # action "Danger" {
+  #    uses = "danger/danger"
+  # }
+  #  ```
+  #
+  # ### Token Setup
+  #
+  # Set DANGER_GITHUB_API_TOKEN to secrets, or you can also use GITHUB_TOKEN.
+  #
+  # ```
+  # action "Danger" {
+  #    uses = "danger/danger"
+  #    secrets = ["GITHUB_TOKEN"]
+  # }
+  # ```
+  #
+  class GitLabCIGitHubPR < CI
+    def self.validates_as_ci?(env)
+      env.key? "GITLAB_PB"
+    end
+
+    def self.validates_as_pr?(env)
+      true
+    end
+
+    def supported_request_sources
+      @supported_request_sources ||= [Danger::RequestSources::GitHub]
+    end
+
+    def initialize(env)
+      self.repo_slug = env['DANGER_REPO_SLUG']
+      self.pull_request_id = env['PULL_REQUEST_ID']
+      self.repo_url = env['DANGER_REPO_URL']
+
+      # if environment variable DANGER_GITHUB_API_TOKEN is not set, use env GITHUB_TOKEN
+      if (env.key? "GITLAB_PB") && (!env.key? 'DANGER_GITHUB_API_TOKEN')
+        env['DANGER_GITHUB_API_TOKEN'] = env['GITHUB_CHANGELOG_TOKEN']
+      end
+    end
+  end
+end

--- a/lib/danger/ci_source/gitlab_ci.rb
+++ b/lib/danger/ci_source/gitlab_ci.rb
@@ -20,7 +20,7 @@ module Danger
     attr_reader :project_url
 
     def self.validates_as_ci?(env)
-      env.key? "GITLAB_CI"
+      false
     end
 
     def self.validates_as_pr?(env)


### PR DESCRIPTION
Danger that works from Gitlab to Github.

Not much else to say, basically we overcome Dangers environment manager, by putting our own env module as first (hence the triple a at the start of the filename for our env module) and inside this we pass the env vars needed for Gitlab to communicate to Github. 

Nothing more, nothing less 🙂 